### PR TITLE
Move the affinity group setup up the task list

### DIFF
--- a/tasks/vm_state_present.yml
+++ b/tasks/vm_state_present.yml
@@ -14,6 +14,9 @@
   retries: "{{ (vm_infra_create_all_timeout|int // vm_infra_create_poll_interval) + 1  }}"
   delay: "{{ vm_infra_create_poll_interval }}"
 
+- name: Apply any Affinity Groups
+  import_tasks: affinity_groups.yml
+
 - name: Manage disks
   ovirt_disk:
     auth: "{{ ovirt_auth }}"
@@ -97,8 +100,6 @@
     query: "[?contains(profile.tag, '{{ item }}')]"
     defined_vms: "{{ create_vms | selectattr('profile.tag', 'defined') | list | unique }}"
 
-- name: Apply any Affinity Groups
-  import_tasks: affinity_groups.yml
 
 - block:
     - set_fact:


### PR DESCRIPTION
Move the affinity group configuration further up the list so that after virtual
machines are added but before they are started, will result in the machines
being scheduled per the affinity rules. By setting the affinity groups before
starting the virtual machines, we avoid having to migrate the virtual machines
after scheduling.